### PR TITLE
browser printing fix, background colours will now be print properly

### DIFF
--- a/R/htmlTable.R
+++ b/R/htmlTable.R
@@ -781,7 +781,7 @@ htmlTable.default <- function(x,
     }
 
 
-    cell_style <- rs <- paste("background-color:", row_clrs[row_nr])
+    cell_style <- rs <- paste("background-color:", row_clrs[row_nr], "!important")
     if (first_row){
       rs %<>%
         c(top_row_style)


### PR DESCRIPTION
A simple solution to a problem we discovered in IE, FF and chrome, where the background-color' was not being displayed in a printed report. This is what I figured to be the most simplistic, yet ugly fix to the problem. Another way to do it would be adding a class, and using the `@media print` selector.

Problems here:
http://stackoverflow.com/questions/14987496/background-color-not-showing-in-print-preview
