### PR TITLE
Graceful handling of empty dataframes

### DIFF
--- a/R/htmlTable.R
+++ b/R/htmlTable.R
@@ -80,6 +80,10 @@
 #' for compatibility reasons. If you set \code{options(table_counter_roman = TRUE)}
 #' then the table counter will use Roman numumerals instead of Arabic.
 #'
+#'@section Empty dataframes:
+#' An empty dataframe will result in a warning and output an empty table, provided that
+#' rgroup and n.rgroup are not specified. All other row layout options will be ignored.
+#'
 #' @section Browsers and possible issues:
 #'
 #' \emph{Copy-pasting:} As you copy-paste results into Word you need to keep
@@ -692,6 +696,7 @@ htmlTable.default <- function(x,
 
   rgroup_iterator <- 0
   tspanner_iterator <- 0
+  if(nrow(x) > 0){
   for (row_nr in 1:nrow(x)){
     rname_style = attr(css.cell, "rnames")[row_nr + !prSkipRownames(rnames)]
 
@@ -844,7 +849,7 @@ htmlTable.default <- function(x,
     table_str %<>%
       paste0(cell_str, "\n\t</tr>")
   }
-
+}
   # Close body
   table_str %<>%
     paste0("\n\t</tbody>")
@@ -907,6 +912,10 @@ prConvertDfFactors <- function(x){
 
 #' @export
 htmlTable.data.frame <- function(x, ...) {
+  # deal gracefully with an empty dataframe - issue a warning.
+  if(nrow(x) == 0){
+    warning(paste(deparse(substitute(x)), "is an empty object"))
+  }
   htmlTable.default(prConvertDfFactors(x),...)
 }
 

--- a/R/txtFrmt.R
+++ b/R/txtFrmt.R
@@ -178,10 +178,10 @@ txtPval <- function(pvalues,
 #' @param x The value/vector/data.frame/matrix to be rounded
 #' @param digits The number of digits to round each element to.
 #'  If you provide a vector each element for corresponding columns.
-#' @param excl.cols Rows to exclude from the rounding procedure.
-#'  This can be either a number or regular expression.
-#' @param excl.rows Columns to exclude from the rounding procedure.
+#' @param excl.cols Columns to exclude from the rounding procedure.
 #'  This can be either a number or regular expression. Skipped if x is a vector.
+#' @param excl.rows Rows to exclude from the rounding procedure.
+#'  This can be either a number or regular expression.
 #' @param txt.NA The string to exchange NA with
 #' @param dec The decimal marker. If the text is in non-english decimal
 #'  and string formatted you need to change this to the apropriate decimal

--- a/inst/examples/htmlTable_example.R
+++ b/inst/examples/htmlTable_example.R
@@ -39,5 +39,25 @@ htmlTable(output, align="r",
           col.rgroup = c("none", "#F7F7F7"),
           css.cell = "padding-left: .5em; padding-right: .2em;")
 
+# An advanced empty table
+output <- matrix(ncol = 6,
+                 nrow = 0)
+
+htmlTable(output, align="r",
+          header =  paste(c("1st", "2nd",
+                            "3rd", "4th",
+                            "5th", "6th"),
+                          "hdr"),
+          cgroup = rbind(c("", "Column spanners", NA),
+                         c("", "Cgroup 1", "Cgroup 2&dagger;")),
+          n.cgroup = rbind(c(1,2,NA),
+                           c(2,2,2)),
+          caption="Basic empty table with column spanners (groups) and ignored row colors",
+          tfoot="&dagger; A table footer commment",
+          cspan.rgroup = 2,
+          col.columns = c(rep("none", 2),
+                          rep("#F5FBFF", 4)),
+          col.rgroup = c("none", "#F7F7F7"),
+          css.cell = "padding-left: .5em; padding-right: .2em;")
 # See vignette("tables", package = "htmlTable")
 # for more examples

--- a/man/htmlTable.Rd
+++ b/man/htmlTable.Rd
@@ -281,6 +281,12 @@ for compatibility reasons. If you set \code{options(table_counter_roman = TRUE)}
 then the table counter will use Roman numumerals instead of Arabic.
 }
 
+\section{Empty dataframes}{
+
+An empty dataframe will result in a warning and output an empty table, provided that
+rgroup and n.rgroup are not specified. All other row layout options will be ignored.
+}
+
 \section{Browsers and possible issues}{
 
 
@@ -360,6 +366,26 @@ htmlTable(output, align="r",
           col.rgroup = c("none", "#F7F7F7"),
           css.cell = "padding-left: .5em; padding-right: .2em;")
 
+# An advanced empty table
+output <- matrix(ncol = 6,
+                 nrow = 0)
+
+htmlTable(output, align="r",
+          header =  paste(c("1st", "2nd",
+                            "3rd", "4th",
+                            "5th", "6th"),
+                          "hdr"),
+          cgroup = rbind(c("", "Column spanners", NA),
+                         c("", "Cgroup 1", "Cgroup 2&dagger;")),
+          n.cgroup = rbind(c(1,2,NA),
+                           c(2,2,2)),
+          caption="Basic empty table with column spanners (groups) and ignored row colors",
+          tfoot="&dagger; A table footer commment",
+          cspan.rgroup = 2,
+          col.columns = c(rep("none", 2),
+                          rep("#F5FBFF", 4)),
+          col.rgroup = c("none", "#F7F7F7"),
+          css.cell = "padding-left: .5em; padding-right: .2em;")
 # See vignette("tables", package = "htmlTable")
 # for more examples
 }

--- a/man/txtRound.Rd
+++ b/man/txtRound.Rd
@@ -29,11 +29,11 @@ If you provide a vector each element for corresponding columns.}
 and string formatted you need to change this to the apropriate decimal
 indicator.}
 
-\item{excl.cols}{Columns to exclude from the rounding procedure.
-This can be either a number or regular expression. Skipped if x is a vector.}
-
-\item{excl.rows}{Rows to exclude from the rounding procedure.
+\item{excl.cols}{Rows to exclude from the rounding procedure.
 This can be either a number or regular expression.}
+
+\item{excl.rows}{Columns to exclude from the rounding procedure.
+This can be either a number or regular expression. Skipped if x is a vector.}
 }
 \value{
 \code{matrix/data.frame}

--- a/man/txtRound.Rd
+++ b/man/txtRound.Rd
@@ -29,11 +29,11 @@ If you provide a vector each element for corresponding columns.}
 and string formatted you need to change this to the apropriate decimal
 indicator.}
 
-\item{excl.cols}{Rows to exclude from the rounding procedure.
-This can be either a number or regular expression.}
-
-\item{excl.rows}{Columns to exclude from the rounding procedure.
+\item{excl.cols}{Columns to exclude from the rounding procedure.
 This can be either a number or regular expression. Skipped if x is a vector.}
+
+\item{excl.rows}{Rows to exclude from the rounding procedure.
+This can be either a number or regular expression.}
 }
 \value{
 \code{matrix/data.frame}

--- a/tests/testthat/test-htmlTable.R
+++ b/tests/testthat/test-htmlTable.R
@@ -304,3 +304,44 @@ test_that("Handling data.frames with factors",{
                                labels = c("1.2")))
   expect_true(txtRound(tmp)$b == 1)
 })
+
+test_that("An empty dataframe returns an empty table with a warning", {
+  empty_dataframe <- data.frame(a = numeric(),
+                      b = factor(levels = c("level one",
+                                            "level two")))
+  expect_warning({
+    htmlTable(empty_dataframe)
+
+    htmlTable(empty_dataframe,
+              cgroup = "Spanner",
+              n.cgroup = 2)
+
+    htmlTable(empty_dataframe,
+              cgroup = "Spanner",
+              n.cgroup = 2,
+              caption = "Caption",
+              tfoot = "Footnote")
+
+    htmlTable(empty_dataframe,
+              col.rgroup = c("white",
+                             "gray"))
+
+    htmlTable(empty_dataframe,
+              rnames = TRUE,
+              rowlabel = "Row number",
+              cgroup = "Spanner",
+              n.cgroup = 2,
+              col.rgroup = c("white",
+                             "gray"))
+
+    htmlTable(empty_dataframe,
+              rnames = TRUE,
+              rowlabel = "Row number",
+              cgroup = "Spanner",
+              n.cgroup = 2,
+              col.rgroup = c("white",
+                             "gray"),
+              caption = "This is a caption",
+              tfoot = "This is a footnote")
+  })
+})


### PR DESCRIPTION
Added code, documentation, tests and an example for graceful handling of empty input.

This is a proposal to fix #11: instead of throwing an error when the input dataframe has 0 rows, it will return an empty table (except when row groups are specified). A typical use case is listings of certain events in clinical trials: if none were recorded, one would want to report an empty table instead of throwing an error.
