### PR TITLE
Bump the development version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: htmlTable
-Version: 1.8
+Version: 1.8.0.9000
 Date: 2017-01-03
 Title: Advanced Tables for Markdown/HTML
 Author: Max Gordon <max@gforge.se>


### PR DESCRIPTION
By doing this I can benefit today from [`utils::packageVersion("htmlTable") > "1.8"`](https://github.com/zeehio/condformat/blob/master/R/condformat_render.R#L58) and later on you can choose to release 1.8.1 or 1.9.