### PR TITLE
check global RStudio preference for inline display

### DIFF
--- a/R/htmlTable.R
+++ b/R/htmlTable.R
@@ -904,8 +904,8 @@ htmlTable.default <- function(x,
                           any(grepl("html_notebook$",
                                     contents[min(header) : max(header)])),
                           FALSE)
-    if (is_notebook) {
-      class(table_str) <- c("html", "htmlTable", class(table_str))
+    if (is_notebook |  isTRUE(.rs.readUiPref("rmd_chunk_output_inline"))) {
+      class(table_str) <- c("html", class(table_str))
       attr(table_str, "html") <- TRUE
     }
   }


### PR DESCRIPTION
Hi Max,

FWIW, here's a bit of code that respects the user's preference for inline display (issue #27).  `.rs.readUIPref()` is undocumented though - it will return a note in Rcmd check.

Peter.