### PR TITLE
Fix pagination widget when single number of entries is given

### DIFF
--- a/inst/htmlwidgets/lib/table_pagination/table_pagination.js
+++ b/inst/htmlwidgets/lib/table_pagination/table_pagination.js
@@ -107,16 +107,25 @@ function table_pagination(table, nav_id, select_entries_div_id, options) {
   // <div><label> Show <select>[10|25|100]</select> entries</label></div>
   var select_entries_div = document.getElementById(select_entries_div_id);
   $(select_entries_div).empty();
+
+  // Get the possible entries per page:
+  var select_entries_allowed = options.number_of_entries;
+  if (select_entries_allowed.length === 0) {
+    select_entries_allowed = [10, 25, 100];
+  }
+
+  // If select_entries_allowed is a scalar, do not offer a select:
+  if (!$.isArray(select_entries_allowed)) {
+    refresh_table(table, nav_id, 0, +select_entries_allowed);
+    return;
+  }
+  // Otherwise show the select menu:
   var label_entries = document.createElement('label');
   var select_entries = document.createElement('select');
   var select_entries_id = select_entries_div_id.concat('_select');
   $(label_entries).attr('for', select_entries_id);
   $(label_entries).append('Show ');
   $(select_entries).attr('id', select_entries_id);
-  var select_entries_allowed = options.number_of_entries;
-  if (select_entries_allowed.length === 0) {
-    select_entries_allowed = [10, 25, 100];
-  }
   for (var i=0;i<select_entries_allowed.length;i++) {
     var option = document.createElement('option');
     $(option).attr('value', select_entries_allowed[i]);


### PR DESCRIPTION
`htmlTable::htmlTableWidget` accepts `number_of_entries` to control the number of rows to show per page. By default we see this "Show 10 entries":
![imatge](https://cloud.githubusercontent.com/assets/75441/26318209/b31a41b8-3f1a-11e7-9515-e9ac67848cf4.png)

However, when `number_of_entries` is a single number, `htmlTableWidget` still was showing a `select` menu that was non-functional.

With this PR, if `number of entries` is not an array we don't create the "Select [10|20|50] entries" label rendering something like this:

![imatge](https://cloud.githubusercontent.com/assets/75441/26318224/c73b7bc6-3f1a-11e7-9d94-003499e5ed2b.png)

Note how the "Show [10] entries" is not there anymore.

I believe this is a much more logical option. Feel free to merge this PR if you want.