### PR TITLE
escape html correctly for dataframes and tibbles

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,7 +33,8 @@ Suggests:
     rmarkdown,
     pander,
     chron,
-    lubridate
+    lubridate,
+    tibble
 Roxygen: list(wrap = FALSE)
 Encoding: UTF-8
 NeedsCompilation: no

--- a/R/htmlTable.R
+++ b/R/htmlTable.R
@@ -342,7 +342,9 @@ htmlTable.default <- function(x,
                               ...)
 {
   if (isTRUE(escape.html)) {
-    x <- htmlEscape(x)
+    attributes_x <- attributes(x)
+    x <- lapply(x, htmlEscape)
+    attributes(x) <- attributes_x
   }
 
   if (is.null(dim(x))){

--- a/inst/doc/general.html
+++ b/inst/doc/general.html
@@ -4,7 +4,7 @@
 
 <head>
 
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="pandoc" />
 
@@ -12,7 +12,7 @@
 
 <meta name="author" content="Max Gordon" />
 
-<meta name="date" content="2017-02-12" />
+<meta name="date" content="2017-11-24" />
 
 <title>The htmlTable package</title>
 
@@ -70,7 +70,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 
 <h1 class="title toc-ignore">The htmlTable package</h1>
 <h4 class="author"><em>Max Gordon</em></h4>
-<h4 class="date"><em>2017-02-12</em></h4>
+<h4 class="date"><em>2017-11-24</em></h4>
 
 
 <div id="TOC">
@@ -98,10 +98,10 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(htmlTable)
 <span class="kw">library</span>(magrittr)
 <span class="co"># A simple output</span>
-<span class="kw">matrix</span>(<span class="dv">1</span>:<span class="dv">4</span>,
+<span class="kw">matrix</span>(<span class="dv">1</span><span class="op">:</span><span class="dv">4</span>,
        <span class="dt">ncol=</span><span class="dv">2</span>,
        <span class="dt">dimnames =</span> <span class="kw">list</span>(<span class="kw">c</span>(<span class="st">&quot;Row 1&quot;</span>, <span class="st">&quot;Row 2&quot;</span>),
-                       <span class="kw">c</span>(<span class="st">&quot;Column 1&quot;</span>, <span class="st">&quot;Column 2&quot;</span>))) %&gt;%<span class="st"> </span>
+                       <span class="kw">c</span>(<span class="st">&quot;Column 1&quot;</span>, <span class="st">&quot;Column 2&quot;</span>))) <span class="op">%&gt;%</span><span class="st"> </span>
 <span class="st">  </span>htmlTable</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
@@ -143,10 +143,10 @@ Row 2
 </table>
 <p>The function is also aware of the dimnames:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="co"># A simple output</span>
-<span class="kw">matrix</span>(<span class="dv">1</span>:<span class="dv">4</span>,
+<span class="kw">matrix</span>(<span class="dv">1</span><span class="op">:</span><span class="dv">4</span>,
        <span class="dt">ncol=</span><span class="dv">2</span>,
        <span class="dt">dimnames =</span> <span class="kw">list</span>(<span class="dt">rows =</span> <span class="kw">c</span>(<span class="st">&quot;Row 1&quot;</span>, <span class="st">&quot;Row 2&quot;</span>),
-                       <span class="dt">cols =</span> <span class="kw">c</span>(<span class="st">&quot;Column 1&quot;</span>, <span class="st">&quot;Column 2&quot;</span>))) %&gt;%<span class="st"> </span>
+                       <span class="dt">cols =</span> <span class="kw">c</span>(<span class="st">&quot;Column 1&quot;</span>, <span class="st">&quot;Column 2&quot;</span>))) <span class="op">%&gt;%</span><span class="st"> </span>
 <span class="st">  </span>htmlTable</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
@@ -174,25 +174,25 @@ Column 2
 rows
 </td>
 </tr>
-<tr style="background-color:;">
-<td style="background-color:; text-align: left;">
+<tr>
+<td style="text-align: left;">
   Row 1
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 1
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 3
 </td>
 </tr>
-<tr style="background-color:;">
-<td style="background-color:; border-bottom: 2px solid grey; text-align: left;">
+<tr>
+<td style="border-bottom: 2px solid grey; text-align: left;">
   Row 2
 </td>
-<td style="background-color:; border-bottom: 2px solid grey; text-align: center;">
+<td style="border-bottom: 2px solid grey; text-align: center;">
 2
 </td>
-<td style="background-color:; border-bottom: 2px solid grey; text-align: center;">
+<td style="border-bottom: 2px solid grey; text-align: center;">
 4
 </td>
 </tr>
@@ -201,8 +201,8 @@ rows
 <p>This can be convenient when working with the <code>base::table</code> function:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">data</span>(<span class="st">&quot;mtcars&quot;</span>)
 <span class="kw">with</span>(mtcars,
-     <span class="kw">table</span>(cyl, gear)) %&gt;%<span class="st"> </span>
-<span class="st">  </span>addmargins %&gt;%<span class="st"> </span>
+     <span class="kw">table</span>(cyl, gear)) <span class="op">%&gt;%</span><span class="st"> </span>
+<span class="st">  </span>addmargins <span class="op">%&gt;%</span><span class="st"> </span>
 <span class="st">  </span>htmlTable</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
@@ -244,83 +244,83 @@ Sum
 cyl
 </td>
 </tr>
-<tr style="background-color:;">
-<td style="background-color:; text-align: left;">
+<tr>
+<td style="text-align: left;">
   4
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 1
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 8
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 2
 </td>
-<td style="background-color:;" colspan="1">
+<td style colspan="1">
  
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 11
 </td>
 </tr>
-<tr style="background-color:;">
-<td style="background-color:; text-align: left;">
+<tr>
+<td style="text-align: left;">
   6
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 2
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 4
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 1
 </td>
-<td style="background-color:;" colspan="1">
+<td style colspan="1">
  
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 7
 </td>
 </tr>
-<tr style="background-color:;">
-<td style="background-color:; text-align: left;">
+<tr>
+<td style="text-align: left;">
   8
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 12
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 0
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 2
 </td>
-<td style="background-color:;" colspan="1">
+<td style colspan="1">
  
 </td>
-<td style="background-color:; text-align: center;">
+<td style="text-align: center;">
 14
 </td>
 </tr>
-<tr style="background-color:;">
-<td style="background-color:; border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900; text-align: left;">
+<tr>
+<td style="border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900; text-align: left;">
   Sum
 </td>
-<td style="background-color:; border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900; text-align: center;">
+<td style="border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900; text-align: center;">
 15
 </td>
-<td style="background-color:; border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900; text-align: center;">
+<td style="border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900; text-align: center;">
 12
 </td>
-<td style="background-color:; border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900; text-align: center;">
+<td style="border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900; text-align: center;">
 5
 </td>
-<td style="background-color:; border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900;" colspan="1">
+<td style="border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900;" colspan="1">
  
 </td>
-<td style="background-color:; border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900; text-align: center;">
+<td style="border-bottom: 2px solid grey; border-top: 1px solid #BEBEBE; font-weight: 900; text-align: center;">
 32
 </td>
 </tr>
@@ -330,7 +330,7 @@ cyl
 <div id="table-caption" class="section level2">
 <h2>Table caption</h2>
 <p>The table caption is simply the table description and can be either located above or below:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">output &lt;-<span class="st"> </span><span class="kw">matrix</span>(<span class="dv">1</span>:<span class="dv">4</span>,
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">output &lt;-<span class="st"> </span><span class="kw">matrix</span>(<span class="dv">1</span><span class="op">:</span><span class="dv">4</span>,
        <span class="dt">ncol=</span><span class="dv">2</span>,
        <span class="dt">dimnames =</span> <span class="kw">list</span>(<span class="kw">c</span>(<span class="st">&quot;Row 1&quot;</span>, <span class="st">&quot;Row 2&quot;</span>),
                        <span class="kw">c</span>(<span class="st">&quot;Column 1&quot;</span>, <span class="st">&quot;Column 2&quot;</span>)))
@@ -431,7 +431,7 @@ A table caption below
 <div id="cell-alignment" class="section level2">
 <h2>Cell alignment</h2>
 <p>Cell alignment is specified through the <code>align</code>, <code>align.header</code>, <code>align.cgroup</code> arguments. For aligning the cell values just use <code>align</code>. The argument can accept either a vector or a string, although supplying it with a string is the simplest option as in the example below:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(<span class="dv">1</span>:<span class="dv">3</span>, 
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(<span class="dv">1</span><span class="op">:</span><span class="dv">3</span>, 
           <span class="dt">rnames =</span> <span class="st">&quot;Row 1&quot;</span>,
           <span class="dt">align =</span> <span class="st">&quot;lcr&quot;</span>,
           <span class="dt">header =</span> <span class="kw">c</span>(<span class="st">&quot;'l' = left&quot;</span>, <span class="st">&quot;'c' = center&quot;</span>, <span class="st">&quot;'r' = right&quot;</span>),
@@ -475,7 +475,7 @@ Row 1
 </tbody>
 </table>
 <p>Note that you can specify a string shorter than the number of columns. This can be useful if you have plenty of columns and you simply want all remaining columns to keep the alignment of the last column. To align the row name you can just add another letter to the string while the header is aligned through the <code>align.header</code> argument:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(<span class="dv">1</span>:<span class="dv">3</span>, 
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(<span class="dv">1</span><span class="op">:</span><span class="dv">3</span>, 
           <span class="dt">rnames =</span> <span class="st">&quot;Row 1&quot;</span>,
           <span class="dt">align =</span> <span class="st">&quot;clcr&quot;</span>,
           <span class="dt">align.header =</span> <span class="st">&quot;lcr&quot;</span>,
@@ -540,15 +540,15 @@ Row 1
 <span class="st">  </span><span class="kw">matrix</span>(<span class="dt">ncol=</span><span class="dv">6</span>, <span class="dt">nrow=</span><span class="dv">8</span>)
 <span class="kw">rownames</span>(mx) &lt;-<span class="st"> </span><span class="kw">paste</span>(<span class="kw">c</span>(<span class="st">&quot;1st&quot;</span>, <span class="st">&quot;2nd&quot;</span>,
                         <span class="st">&quot;3rd&quot;</span>,
-                        <span class="kw">paste0</span>(<span class="dv">4</span>:<span class="dv">8</span>, <span class="st">&quot;th&quot;</span>)),
+                        <span class="kw">paste0</span>(<span class="dv">4</span><span class="op">:</span><span class="dv">8</span>, <span class="st">&quot;th&quot;</span>)),
                       <span class="st">&quot;row&quot;</span>)
 <span class="kw">colnames</span>(mx) &lt;-<span class="st"> </span><span class="kw">paste</span>(<span class="kw">c</span>(<span class="st">&quot;1st&quot;</span>, <span class="st">&quot;2nd&quot;</span>,
                         <span class="st">&quot;3rd&quot;</span>, 
-                        <span class="kw">paste0</span>(<span class="dv">4</span>:<span class="dv">6</span>, <span class="st">&quot;th&quot;</span>)),
+                        <span class="kw">paste0</span>(<span class="dv">4</span><span class="op">:</span><span class="dv">6</span>, <span class="st">&quot;th&quot;</span>)),
                       <span class="st">&quot;hdr&quot;</span>)
 
-for (nr in <span class="dv">1</span>:<span class="kw">nrow</span>(mx)){
-  for (nc in <span class="dv">1</span>:<span class="kw">ncol</span>(mx)){
+<span class="cf">for</span> (nr <span class="cf">in</span> <span class="dv">1</span><span class="op">:</span><span class="kw">nrow</span>(mx)){
+  <span class="cf">for</span> (nc <span class="cf">in</span> <span class="dv">1</span><span class="op">:</span><span class="kw">ncol</span>(mx)){
     mx[nr, nc] &lt;-
 <span class="st">      </span><span class="kw">paste0</span>(nr, <span class="st">&quot;:&quot;</span>, nc)
   }
@@ -557,8 +557,8 @@ for (nr in <span class="dv">1</span>:<span class="kw">nrow</span>(mx)){
 <h2>Row groups</h2>
 <p>The purpose of the row groups is to group variables that belong to the same group, e.g. a factored variable with more than two levels often benefit from grouping variables together.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx, 
-          <span class="dt">rgroup =</span> <span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span>:<span class="dv">3</span>]),
-          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) -<span class="st"> </span><span class="dv">6</span>))</code></pre></div>
+          <span class="dt">rgroup =</span> <span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span><span class="op">:</span><span class="dv">3</span>]),
+          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) <span class="op">-</span><span class="st"> </span><span class="dv">6</span>))</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
 <tr>
@@ -788,8 +788,8 @@ Group C
 </table>
 <p>We can easily mix row groups with regular variables by having an empty row group name <code>&quot;&quot;</code>:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx, 
-          <span class="dt">rgroup =</span> <span class="kw">c</span>(<span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span>:<span class="dv">2</span>]), <span class="st">&quot;&quot;</span>),
-          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) -<span class="st"> </span><span class="dv">6</span>))</code></pre></div>
+          <span class="dt">rgroup =</span> <span class="kw">c</span>(<span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span><span class="op">:</span><span class="dv">2</span>]), <span class="st">&quot;&quot;</span>),
+          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) <span class="op">-</span><span class="st"> </span><span class="dv">6</span>))</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
 <tr>
@@ -1015,8 +1015,8 @@ Group B
 <p>When mixing row groups with variables without row groups we may want to omit the bold formatting of the row group label:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx, 
           <span class="dt">css.rgroup =</span> <span class="st">&quot;&quot;</span>,
-          <span class="dt">rgroup =</span> <span class="kw">c</span>(<span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span>:<span class="dv">2</span>]), <span class="st">&quot;&quot;</span>),
-          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) -<span class="st"> </span><span class="dv">6</span>))</code></pre></div>
+          <span class="dt">rgroup =</span> <span class="kw">c</span>(<span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span><span class="op">:</span><span class="dv">2</span>]), <span class="st">&quot;&quot;</span>),
+          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) <span class="op">-</span><span class="st"> </span><span class="dv">6</span>))</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
 <tr>
@@ -1240,11 +1240,11 @@ Group B
 </tbody>
 </table>
 <p>The <code>rgroup</code> is most commonly a single row without any additional cells but sometimes you may want to have a p-value or similar at the end of the row. This can be achieved by setting the ‘add’ attribute to the <code>rgroup</code>:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">rgroup &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span>:<span class="dv">2</span>]), <span class="st">&quot;&quot;</span>)
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">rgroup &lt;-<span class="st"> </span><span class="kw">c</span>(<span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span><span class="op">:</span><span class="dv">2</span>]), <span class="st">&quot;&quot;</span>)
 <span class="kw">attr</span>(rgroup, <span class="st">&quot;add&quot;</span>) &lt;-<span class="st"> </span><span class="kw">list</span>(<span class="st">`</span><span class="dt">2</span><span class="st">`</span> =<span class="st"> &quot;More&quot;</span>)
 <span class="kw">htmlTable</span>(mx, 
           <span class="dt">rgroup =</span> rgroup,
-          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) -<span class="st"> </span><span class="dv">6</span>))</code></pre></div>
+          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) <span class="op">-</span><span class="st"> </span><span class="dv">6</span>))</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
 <tr>
@@ -2365,8 +2365,8 @@ Cgroup 2
 <h2>Table spanners</h2>
 <p>A table spanner is similar to rgroup but has the primary purpose of combining 2 or more tables with the same columns into one:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx, 
-          <span class="dt">tspanner =</span> <span class="kw">paste</span>(<span class="st">&quot;Spanner&quot;</span>, LETTERS[<span class="dv">1</span>:<span class="dv">3</span>]),
-          <span class="dt">n.tspanner =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) -<span class="st"> </span><span class="dv">6</span>))</code></pre></div>
+          <span class="dt">tspanner =</span> <span class="kw">paste</span>(<span class="st">&quot;Spanner&quot;</span>, LETTERS[<span class="dv">1</span><span class="op">:</span><span class="dv">3</span>]),
+          <span class="dt">n.tspanner =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) <span class="op">-</span><span class="st"> </span><span class="dv">6</span>))</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
 <tr>
@@ -2598,7 +2598,7 @@ Spanner C
 <div id="total-row" class="section level2">
 <h2>Total row</h2>
 <p>Many financial tables use the concept of a total row at the end that sums the above elements:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx[<span class="dv">1</span>:<span class="dv">3</span>,], <span class="dt">total=</span><span class="ot">TRUE</span>)</code></pre></div>
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx[<span class="dv">1</span><span class="op">:</span><span class="dv">3</span>,], <span class="dt">total=</span><span class="ot">TRUE</span>)</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
 <tr>
@@ -2702,8 +2702,8 @@ Spanner C
           <span class="dt">css.total =</span> <span class="kw">c</span>(<span class="st">&quot;border-top: 1px dashed grey;&quot;</span>,
                         <span class="st">&quot;border-top: 1px dashed grey;&quot;</span>,
                         <span class="st">&quot;border-top: 1px solid grey; font-weight: 900&quot;</span>),
-          <span class="dt">tspanner =</span> <span class="kw">paste</span>(<span class="st">&quot;Spanner&quot;</span>, LETTERS[<span class="dv">1</span>:<span class="dv">3</span>]),
-          <span class="dt">n.tspanner =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) -<span class="st"> </span><span class="dv">6</span>))</code></pre></div>
+          <span class="dt">tspanner =</span> <span class="kw">paste</span>(<span class="st">&quot;Spanner&quot;</span>, LETTERS[<span class="dv">1</span><span class="op">:</span><span class="dv">3</span>]),
+          <span class="dt">n.tspanner =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) <span class="op">-</span><span class="st"> </span><span class="dv">6</span>))</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
 <tr>
@@ -2936,7 +2936,7 @@ Spanner C
 <h2>Table numbering</h2>
 <p>The htmlTable has built-in numbering, initialized by:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">options</span>(<span class="dt">table_counter =</span> <span class="ot">TRUE</span>)</code></pre></div>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx[<span class="dv">1</span>:<span class="dv">2</span>,<span class="dv">1</span>:<span class="dv">2</span>], 
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx[<span class="dv">1</span><span class="op">:</span><span class="dv">2</span>,<span class="dv">1</span><span class="op">:</span><span class="dv">2</span>], 
           <span class="dt">caption=</span><span class="st">&quot;A table caption with a numbering&quot;</span>)</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;" id="table_1">
 <thead>
@@ -2986,7 +2986,7 @@ Table 1: A table caption with a numbering
 <pre><code>## [1] 1</code></pre>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">tblNoNext</span>()</code></pre></div>
 <pre><code>## [1] 2</code></pre>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx[<span class="dv">1</span>:<span class="dv">2</span>,<span class="dv">1</span>:<span class="dv">2</span>], 
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx[<span class="dv">1</span><span class="op">:</span><span class="dv">2</span>,<span class="dv">1</span><span class="op">:</span><span class="dv">2</span>], 
           <span class="dt">caption=</span><span class="st">&quot;Another table with numbering&quot;</span>)</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;" id="table_2">
 <thead>
@@ -3037,7 +3037,7 @@ Table 2: Another table with numbering
 <div id="table-footer" class="section level2">
 <h2>Table footer</h2>
 <p>The footer usually contains specifics regarding variables and is always located at the foot of the table:</p>
-<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx[<span class="dv">1</span>:<span class="dv">2</span>,<span class="dv">1</span>:<span class="dv">2</span>], 
+<div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx[<span class="dv">1</span><span class="op">:</span><span class="dv">2</span>,<span class="dv">1</span><span class="op">:</span><span class="dv">2</span>], 
           <span class="dt">tfoot=</span><span class="st">&quot;A table footer&quot;</span>)</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
@@ -3305,8 +3305,8 @@ A table footer
 <p>The zebra coloring in <code>htmlTable</code> is unique in that it follows the rgroups. The zebra striping is centered around the rgroup although rows with no set rgroup, i.e. “” will have alternating colors event though they programatically are within the same group:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx, 
           <span class="dt">col.rgroup =</span> <span class="kw">c</span>(<span class="st">&quot;none&quot;</span>, <span class="st">&quot;#F7F7F7&quot;</span>),
-          <span class="dt">rgroup =</span> <span class="kw">c</span>(<span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span>:<span class="dv">2</span>]), <span class="st">&quot;&quot;</span>),
-          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">2</span>,<span class="kw">nrow</span>(mx) -<span class="st"> </span><span class="dv">4</span>))</code></pre></div>
+          <span class="dt">rgroup =</span> <span class="kw">c</span>(<span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span><span class="op">:</span><span class="dv">2</span>]), <span class="st">&quot;&quot;</span>),
+          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">2</span>,<span class="kw">nrow</span>(mx) <span class="op">-</span><span class="st"> </span><span class="dv">4</span>))</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
 <tr>
@@ -3966,8 +3966,8 @@ Group B
 <p>Now if we want to do everything in one table it may look like this:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(mx, 
           <span class="dt">align=</span><span class="st">&quot;r&quot;</span>,
-          <span class="dt">rgroup =</span> <span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span>:<span class="dv">3</span>]),
-          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) -<span class="st"> </span><span class="dv">6</span>),
+          <span class="dt">rgroup =</span> <span class="kw">paste</span>(<span class="st">&quot;Group&quot;</span>, LETTERS[<span class="dv">1</span><span class="op">:</span><span class="dv">3</span>]),
+          <span class="dt">n.rgroup =</span> <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">4</span>,<span class="kw">nrow</span>(mx) <span class="op">-</span><span class="st"> </span><span class="dv">6</span>),
           <span class="dt">cgroup =</span> <span class="kw">rbind</span>(<span class="kw">c</span>(<span class="st">&quot;&quot;</span>, <span class="st">&quot;Column spanners&quot;</span>, <span class="ot">NA</span>),
                          <span class="kw">c</span>(<span class="st">&quot;&quot;</span>, <span class="st">&quot;Cgroup 1&quot;</span>, <span class="st">&quot;Cgroup 2&amp;dagger;&quot;</span>)),
           <span class="dt">n.cgroup =</span> <span class="kw">rbind</span>(<span class="kw">c</span>(<span class="dv">1</span>,<span class="dv">2</span>,<span class="ot">NA</span>),
@@ -4360,7 +4360,7 @@ Group C
   (function () {
     var script = document.createElement("script");
     script.type = "text/javascript";
-    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    script.src  = "https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
     document.getElementsByTagName("head")[0].appendChild(script);
   })();
 </script>

--- a/inst/doc/tables.R
+++ b/inst/doc/tables.R
@@ -171,7 +171,8 @@ htmlTable(out_mx,
           n.rgroup = rep(5, 3),
           tfoot = txtMergeLines("&Delta;<sub>int</sub> correspnds to the change since start",
                                 "&Delta;<sub>std</sub> corresponds to the change compared to national average"),
-          cspan.rgroup = 1)
+          cspan.rgroup = 1,
+          escape.html = FALSE)
 
 ## ---- message=FALSE, results='asis'--------------------------------------
 library(ztable)

--- a/inst/doc/tables.Rmd
+++ b/inst/doc/tables.Rmd
@@ -208,7 +208,7 @@ htmlTable(txtRound(mx, 1),
           cspan.rgroup = 1)
 ```
 
-If you want to further add to the visual hints you can use specific HTML-code and insert it into the cells. Here we will color the &Delta;<sub>std</sub> according to color.
+If you want to further add to the visual hints you can use specific HTML-code and insert it into the cells. Here we will color the &Delta;<sub>std</sub> according to color. By default htmlTable escapes HTML characters. If we want the HTML code to be interpreted correctly we need to make sure that this does not happen, by specifying `escape.html = FALSE`.
 
 ```{r}
 cols_2_clr <- grep("&Delta;<sub>std</sub>", colnames(mx))
@@ -249,7 +249,8 @@ htmlTable(out_mx,
           n.rgroup = rep(5, 3),
           tfoot = txtMergeLines("&Delta;<sub>int</sub> correspnds to the change since start",
                                 "&Delta;<sub>std</sub> corresponds to the change compared to national average"),
-          cspan.rgroup = 1)
+          cspan.rgroup = 1,
+          escape.html = FALSE)
 ```
 
 Although a graph most likely does the visualization task better, tables are good at conveying detailed information. It is in my mind without doubt easier in the latest version to find the pattern in the data.

--- a/inst/doc/tables.html
+++ b/inst/doc/tables.html
@@ -4,7 +4,7 @@
 
 <head>
 
-<meta charset="utf-8">
+<meta charset="utf-8" />
 <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
 <meta name="generator" content="pandoc" />
 
@@ -12,7 +12,7 @@
 
 <meta name="author" content="Max Gordon" />
 
-<meta name="date" content="2017-02-12" />
+<meta name="date" content="2017-11-24" />
 
 <title>Tables with htmlTable and some alternatives</title>
 
@@ -70,7 +70,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 
 <h1 class="title toc-ignore">Tables with htmlTable and some alternatives</h1>
 <h4 class="author"><em>Max Gordon</em></h4>
-<h4 class="date"><em>2017-02-12</em></h4>
+<h4 class="date"><em>2017-11-24</em></h4>
 
 
 <div id="TOC">
@@ -110,7 +110,7 @@ code > span.in { color: #60a0b0; font-weight: bold; font-style: italic; } /* Inf
 <h2>The <code>htmlTable</code>-package</h2>
 <p>I developed the <code>htmlTable</code> in order to get tables matching those available in top medical journals. After finding no HTML-alternative to the <code>Hmisc::latex</code> function on <a href="http://stackoverflow.com/questions/11950703/html-with-multicolumn-table-in-markdown-using-knitr">Stack Overflow</a> I wrote a basic function allowing column spanners and row groups. Below is a basic example on these two:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">output &lt;-<span class="st"> </span>
-<span class="st">  </span><span class="kw">matrix</span>(<span class="kw">paste</span>(<span class="st">&quot;Content&quot;</span>, LETTERS[<span class="dv">1</span>:<span class="dv">16</span>]), 
+<span class="st">  </span><span class="kw">matrix</span>(<span class="kw">paste</span>(<span class="st">&quot;Content&quot;</span>, LETTERS[<span class="dv">1</span><span class="op">:</span><span class="dv">16</span>]), 
          <span class="dt">ncol=</span><span class="dv">4</span>, <span class="dt">byrow =</span> <span class="ot">TRUE</span>)
 
 <span class="kw">library</span>(htmlTable)
@@ -274,12 +274,12 @@ Content P
 
 <span class="co"># The SCB has three other coulmns and one value column</span>
 <span class="kw">library</span>(reshape)
-SCB$region &lt;-<span class="st"> </span><span class="kw">relevel</span>(SCB$region, <span class="st">&quot;Sweden&quot;</span>)
-SCB &lt;-<span class="st"> </span><span class="kw">cast</span>(SCB, year ~<span class="st"> </span>region +<span class="st"> </span>sex, <span class="dt">value =</span> <span class="st">&quot;values&quot;</span>)
+SCB<span class="op">$</span>region &lt;-<span class="st"> </span><span class="kw">relevel</span>(SCB<span class="op">$</span>region, <span class="st">&quot;Sweden&quot;</span>)
+SCB &lt;-<span class="st"> </span><span class="kw">cast</span>(SCB, year <span class="op">~</span><span class="st"> </span>region <span class="op">+</span><span class="st"> </span>sex, <span class="dt">value =</span> <span class="st">&quot;values&quot;</span>)
 
 <span class="co"># Set rownames to be year</span>
-<span class="kw">rownames</span>(SCB) &lt;-<span class="st"> </span>SCB$year
-SCB$year &lt;-<span class="st"> </span><span class="ot">NULL</span>
+<span class="kw">rownames</span>(SCB) &lt;-<span class="st"> </span>SCB<span class="op">$</span>year
+SCB<span class="op">$</span>year &lt;-<span class="st"> </span><span class="ot">NULL</span>
 
 <span class="co"># The dataset now has the rows</span>
 <span class="kw">names</span>(SCB)</code></pre></div>
@@ -338,42 +338,42 @@ Age
 </tr>
 </table>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">mx &lt;-<span class="st"> </span><span class="ot">NULL</span>
-for (n in <span class="kw">names</span>(SCB)){
+<span class="cf">for</span> (n <span class="cf">in</span> <span class="kw">names</span>(SCB)){
   tmp &lt;-<span class="st"> </span><span class="kw">paste0</span>(<span class="st">&quot;Sweden_&quot;</span>, <span class="kw">strsplit</span>(n, <span class="st">&quot;_&quot;</span>)[[<span class="dv">1</span>]][<span class="dv">2</span>])
   mx &lt;-<span class="st"> </span><span class="kw">cbind</span>(mx,
               <span class="kw">cbind</span>(SCB[[n]], 
-                    SCB[[n]] -<span class="st"> </span>SCB[[n]][<span class="dv">1</span>],
-                    SCB[[n]] -<span class="st"> </span>SCB[[tmp]]))
+                    SCB[[n]] <span class="op">-</span><span class="st"> </span>SCB[[n]][<span class="dv">1</span>],
+                    SCB[[n]] <span class="op">-</span><span class="st"> </span>SCB[[tmp]]))
 }
 <span class="kw">rownames</span>(mx) &lt;-<span class="st"> </span><span class="kw">rownames</span>(SCB)
 <span class="kw">colnames</span>(mx) &lt;-<span class="st"> </span><span class="kw">rep</span>(<span class="kw">c</span>(<span class="st">&quot;Age&quot;</span>, 
                       <span class="st">&quot;&amp;Delta;&lt;sub&gt;int&lt;/sub&gt;&quot;</span>,
                       <span class="st">&quot;&amp;Delta;&lt;sub&gt;std&lt;/sub&gt;&quot;</span>), 
                     <span class="dt">times =</span> <span class="kw">ncol</span>(SCB))
-mx &lt;-<span class="st"> </span>mx[,<span class="kw">c</span>(-<span class="dv">3</span>, -<span class="dv">6</span>)]
+mx &lt;-<span class="st"> </span>mx[,<span class="kw">c</span>(<span class="op">-</span><span class="dv">3</span>, <span class="op">-</span><span class="dv">6</span>)]
 
 <span class="co"># This automated generation of cgroup elements is </span>
 <span class="co"># somewhat of an overkill</span>
 cgroup &lt;-<span class="st"> </span>
 <span class="st">  </span><span class="kw">unique</span>(<span class="kw">sapply</span>(<span class="kw">names</span>(SCB), 
-                function(x) <span class="kw">strsplit</span>(x, <span class="st">&quot;_&quot;</span>)[[<span class="dv">1</span>]][<span class="dv">1</span>], 
+                <span class="cf">function</span>(x) <span class="kw">strsplit</span>(x, <span class="st">&quot;_&quot;</span>)[[<span class="dv">1</span>]][<span class="dv">1</span>], 
                 <span class="dt">USE.NAMES =</span> <span class="ot">FALSE</span>))
 n.cgroup &lt;-<span class="st"> </span>
 <span class="st">  </span><span class="kw">sapply</span>(cgroup, 
-         function(x) <span class="kw">sum</span>(<span class="kw">grepl</span>(<span class="kw">paste0</span>(<span class="st">&quot;^&quot;</span>, x), <span class="kw">names</span>(SCB))), 
-         <span class="dt">USE.NAMES =</span> <span class="ot">FALSE</span>)*<span class="dv">3</span>
-n.cgroup[cgroup ==<span class="st"> &quot;Sweden&quot;</span>] &lt;-
-<span class="st">  </span>n.cgroup[cgroup ==<span class="st"> &quot;Sweden&quot;</span>] -<span class="st"> </span><span class="dv">2</span>
+         <span class="cf">function</span>(x) <span class="kw">sum</span>(<span class="kw">grepl</span>(<span class="kw">paste0</span>(<span class="st">&quot;^&quot;</span>, x), <span class="kw">names</span>(SCB))), 
+         <span class="dt">USE.NAMES =</span> <span class="ot">FALSE</span>)<span class="op">*</span><span class="dv">3</span>
+n.cgroup[cgroup <span class="op">==</span><span class="st"> &quot;Sweden&quot;</span>] &lt;-
+<span class="st">  </span>n.cgroup[cgroup <span class="op">==</span><span class="st"> &quot;Sweden&quot;</span>] <span class="op">-</span><span class="st"> </span><span class="dv">2</span>
 
 cgroup &lt;-<span class="st"> </span>
-<span class="st">  </span><span class="kw">rbind</span>(<span class="kw">c</span>(cgroup, <span class="kw">rep</span>(<span class="ot">NA</span>, <span class="kw">ncol</span>(SCB) -<span class="st"> </span><span class="kw">length</span>(cgroup))),
-        Hmisc::<span class="kw">capitalize</span>(
+<span class="st">  </span><span class="kw">rbind</span>(<span class="kw">c</span>(cgroup, <span class="kw">rep</span>(<span class="ot">NA</span>, <span class="kw">ncol</span>(SCB) <span class="op">-</span><span class="st"> </span><span class="kw">length</span>(cgroup))),
+        Hmisc<span class="op">::</span><span class="kw">capitalize</span>(
           <span class="kw">sapply</span>(<span class="kw">names</span>(SCB), 
-                 function(x) <span class="kw">strsplit</span>(x, <span class="st">&quot;_&quot;</span>)[[<span class="dv">1</span>]][<span class="dv">2</span>],
+                 <span class="cf">function</span>(x) <span class="kw">strsplit</span>(x, <span class="st">&quot;_&quot;</span>)[[<span class="dv">1</span>]][<span class="dv">2</span>],
                  <span class="dt">USE.NAMES =</span> <span class="ot">FALSE</span>)))
 n.cgroup &lt;-<span class="st"> </span>
-<span class="st">  </span><span class="kw">rbind</span>(<span class="kw">c</span>(n.cgroup, <span class="kw">rep</span>(<span class="ot">NA</span>, <span class="kw">ncol</span>(SCB) -<span class="st"> </span><span class="kw">length</span>(n.cgroup))),
-        <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">2</span>, <span class="kw">rep</span>(<span class="dv">3</span>, <span class="kw">ncol</span>(cgroup) -<span class="st"> </span><span class="dv">2</span>)))
+<span class="st">  </span><span class="kw">rbind</span>(<span class="kw">c</span>(n.cgroup, <span class="kw">rep</span>(<span class="ot">NA</span>, <span class="kw">ncol</span>(SCB) <span class="op">-</span><span class="st"> </span><span class="kw">length</span>(n.cgroup))),
+        <span class="kw">c</span>(<span class="dv">2</span>,<span class="dv">2</span>, <span class="kw">rep</span>(<span class="dv">3</span>, <span class="kw">ncol</span>(cgroup) <span class="op">-</span><span class="st"> </span><span class="dv">2</span>)))
 
 <span class="kw">print</span>(cgroup)</code></pre></div>
 <pre><code>##      [,1]     [,2]                [,3]               [,4]            
@@ -3556,7 +3556,7 @@ Third period
 <p>If we still feel that we want more separation it is always possible to add colors.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(<span class="kw">txtRound</span>(mx, <span class="dv">1</span>), 
           <span class="dt">col.columns =</span> <span class="kw">c</span>(<span class="kw">rep</span>(<span class="st">&quot;#E6E6F0&quot;</span>, <span class="dv">4</span>),
-                          <span class="kw">rep</span>(<span class="st">&quot;none&quot;</span>, <span class="kw">ncol</span>(mx) -<span class="st"> </span><span class="dv">4</span>)),
+                          <span class="kw">rep</span>(<span class="st">&quot;none&quot;</span>, <span class="kw">ncol</span>(mx) <span class="op">-</span><span class="st"> </span><span class="dv">4</span>)),
           <span class="dt">align=</span><span class="st">&quot;rrrr|r&quot;</span>,
           <span class="dt">cgroup =</span> cgroup,
           <span class="dt">n.cgroup =</span> n.cgroup,
@@ -5143,7 +5143,7 @@ Third period
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">htmlTable</span>(<span class="kw">txtRound</span>(mx, <span class="dv">1</span>),
           <span class="dt">col.rgroup =</span> <span class="kw">c</span>(<span class="st">&quot;none&quot;</span>, <span class="st">&quot;#FFFFCC&quot;</span>),
           <span class="dt">col.columns =</span> <span class="kw">c</span>(<span class="kw">rep</span>(<span class="st">&quot;#EFEFF0&quot;</span>, <span class="dv">4</span>),
-                          <span class="kw">rep</span>(<span class="st">&quot;none&quot;</span>, <span class="kw">ncol</span>(mx) -<span class="st"> </span><span class="dv">4</span>)),
+                          <span class="kw">rep</span>(<span class="st">&quot;none&quot;</span>, <span class="kw">ncol</span>(mx) <span class="op">-</span><span class="st"> </span><span class="dv">4</span>)),
           <span class="dt">align=</span><span class="st">&quot;rrrr|r&quot;</span>,
           <span class="dt">cgroup =</span> cgroup,
           <span class="dt">n.cgroup =</span> n.cgroup,
@@ -6925,22 +6925,22 @@ Age
 </tr>
 </tfoot>
 </table>
-<p>If you want to further add to the visual hints you can use specific HTML-code and insert it into the cells. Here we will color the Δ<sub>std</sub> according to color.</p>
+<p>If you want to further add to the visual hints you can use specific HTML-code and insert it into the cells. Here we will color the Δ<sub>std</sub> according to color. By default htmlTable escapes HTML characters. If we want the HTML code to be interpreted correctly we need to make sure that this does not happen, by specifying <code>escape.html = FALSE</code>.</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">cols_2_clr &lt;-<span class="st"> </span><span class="kw">grep</span>(<span class="st">&quot;&amp;Delta;&lt;sub&gt;std&lt;/sub&gt;&quot;</span>, <span class="kw">colnames</span>(mx))
 <span class="co"># We need a copy as the formatting causes the matrix to loos</span>
 <span class="co"># its numerical property</span>
 out_mx &lt;-<span class="st"> </span><span class="kw">txtRound</span>(mx, <span class="dv">1</span>)
 
 min_delta &lt;-<span class="st"> </span><span class="kw">min</span>(mx[,cols_2_clr])
-span_delta &lt;-<span class="st"> </span><span class="kw">max</span>(mx[,cols_2_clr]) -<span class="st"> </span><span class="kw">min</span>(mx[,cols_2_clr]) 
-for (col in cols_2_clr){
-  out_mx[, col] &lt;-<span class="st"> </span><span class="kw">mapply</span>(function(val, strength)
+span_delta &lt;-<span class="st"> </span><span class="kw">max</span>(mx[,cols_2_clr]) <span class="op">-</span><span class="st"> </span><span class="kw">min</span>(mx[,cols_2_clr]) 
+<span class="cf">for</span> (col <span class="cf">in</span> cols_2_clr){
+  out_mx[, col] &lt;-<span class="st"> </span><span class="kw">mapply</span>(<span class="cf">function</span>(val, strength)
     <span class="kw">paste0</span>(<span class="st">&quot;&lt;span style='font-weight: 900; color: &quot;</span>, 
            <span class="kw">colorRampPalette</span>(<span class="kw">c</span>(<span class="st">&quot;#009900&quot;</span>, <span class="st">&quot;#000000&quot;</span>, <span class="st">&quot;#990033&quot;</span>))(<span class="dv">101</span>)[strength],
            <span class="st">&quot;'&gt;&quot;</span>,
            val, <span class="st">&quot;&lt;/span&gt;&quot;</span>), 
     <span class="dt">val =</span> out_mx[,col], 
-    <span class="dt">strength =</span> <span class="kw">round</span>((mx[,col] -<span class="st"> </span>min_delta)/span_delta*<span class="dv">100</span> +<span class="st"> </span><span class="dv">1</span>),
+    <span class="dt">strength =</span> <span class="kw">round</span>((mx[,col] <span class="op">-</span><span class="st"> </span>min_delta)<span class="op">/</span>span_delta<span class="op">*</span><span class="dv">100</span> <span class="op">+</span><span class="st"> </span><span class="dv">1</span>),
     <span class="dt">USE.NAMES =</span> <span class="ot">FALSE</span>)
 }
 
@@ -6954,7 +6954,7 @@ for (col in cols_2_clr){
           <span class="dt">rowlabel=</span><span class="st">&quot;Year&quot;</span>, 
           <span class="dt">col.rgroup =</span> <span class="kw">c</span>(<span class="st">&quot;none&quot;</span>, <span class="st">&quot;#FFFFCC&quot;</span>),
           <span class="dt">col.columns =</span> <span class="kw">c</span>(<span class="kw">rep</span>(<span class="st">&quot;#EFEFF0&quot;</span>, <span class="dv">4</span>),
-                          <span class="kw">rep</span>(<span class="st">&quot;none&quot;</span>, <span class="kw">ncol</span>(mx) -<span class="st"> </span><span class="dv">4</span>)),
+                          <span class="kw">rep</span>(<span class="st">&quot;none&quot;</span>, <span class="kw">ncol</span>(mx) <span class="op">-</span><span class="st"> </span><span class="dv">4</span>)),
           <span class="dt">align=</span><span class="st">&quot;rrrr|r&quot;</span>,
           <span class="dt">cgroup =</span> cgroup,
           <span class="dt">n.cgroup =</span> n.cgroup,
@@ -6964,7 +6964,8 @@ for (col in cols_2_clr){
           <span class="dt">n.rgroup =</span> <span class="kw">rep</span>(<span class="dv">5</span>, <span class="dv">3</span>),
           <span class="dt">tfoot =</span> <span class="kw">txtMergeLines</span>(<span class="st">&quot;&amp;Delta;&lt;sub&gt;int&lt;/sub&gt; correspnds to the change since start&quot;</span>,
                                 <span class="st">&quot;&amp;Delta;&lt;sub&gt;std&lt;/sub&gt; corresponds to the change compared to national average&quot;</span>),
-          <span class="dt">cspan.rgroup =</span> <span class="dv">1</span>)</code></pre></div>
+          <span class="dt">cspan.rgroup =</span> <span class="dv">1</span>,
+          <span class="dt">escape.html =</span> <span class="ot">FALSE</span>)</code></pre></div>
 <table class="gmisc_table" style="border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;">
 <thead>
 <tr>
@@ -8758,7 +8759,7 @@ zt &lt;-<span class="st"> </span><span class="kw">ztable</span>(out_mx,
 <span class="st">             population of students.&quot;</span>,
              <span class="dt">zebra.type =</span> <span class="dv">1</span>,
              <span class="dt">zebra =</span> <span class="st">&quot;peach&quot;</span>,
-             <span class="dt">align=</span><span class="kw">paste</span>(<span class="kw">rep</span>(<span class="st">&quot;r&quot;</span>, <span class="kw">ncol</span>(out_mx) +<span class="st"> </span><span class="dv">1</span>), <span class="dt">collapse =</span> <span class="st">&quot;&quot;</span>))
+             <span class="dt">align=</span><span class="kw">paste</span>(<span class="kw">rep</span>(<span class="st">&quot;r&quot;</span>, <span class="kw">ncol</span>(out_mx) <span class="op">+</span><span class="st"> </span><span class="dv">1</span>), <span class="dt">collapse =</span> <span class="st">&quot;&quot;</span>))
 <span class="co"># zt &lt;- addcgroup(zt,</span>
 <span class="co">#                 cgroup = cgroup,</span>
 <span class="co">#                 n.cgroup = n.cgroup)</span>
@@ -9948,7 +9949,7 @@ Age
 <h3>The <code>xtable</code>-package</h3>
 <p>The <code>xtable</code> is a solution that delivers both HTML and LaTeX. The syntax is very similar to <code>kable</code>:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r">output &lt;-<span class="st"> </span>
-<span class="st">  </span><span class="kw">matrix</span>(<span class="kw">sprintf</span>(<span class="st">&quot;Content %s&quot;</span>, LETTERS[<span class="dv">1</span>:<span class="dv">4</span>]),
+<span class="st">  </span><span class="kw">matrix</span>(<span class="kw">sprintf</span>(<span class="st">&quot;Content %s&quot;</span>, LETTERS[<span class="dv">1</span><span class="op">:</span><span class="dv">4</span>]),
          <span class="dt">ncol=</span><span class="dv">2</span>, <span class="dt">byrow=</span><span class="ot">TRUE</span>)
 <span class="kw">colnames</span>(output) &lt;-<span class="st"> </span>
 <span class="st">  </span><span class="kw">c</span>(<span class="st">&quot;1st header&quot;</span>, <span class="st">&quot;2nd header&quot;</span>)
@@ -9960,8 +9961,8 @@ Age
              <span class="dt">caption=</span><span class="st">&quot;A test table&quot;</span>, 
              <span class="dt">align =</span> <span class="kw">c</span>(<span class="st">&quot;l&quot;</span>, <span class="st">&quot;c&quot;</span>, <span class="st">&quot;r&quot;</span>)), 
       <span class="dt">type=</span><span class="st">&quot;html&quot;</span>)</code></pre></div>
-<!-- html table generated in R 3.3.2 by xtable 1.8-2 package -->
-<!-- Sun Feb 12 14:20:40 2017 -->
+<!-- html table generated in R 3.4.2 by xtable 1.8-2 package -->
+<!-- Fri Nov 24 01:39:03 2017 -->
 <table border="1">
 <caption align="bottom">
 A test table
@@ -10076,11 +10077,11 @@ Content C   | Content D
 <p>Another option is to use the pander function that can help with text-formatting inside a markdown-compatible table (Thanks Gergely Daróczi for the tip). Here’s a simple example:</p>
 <div class="sourceCode"><pre class="sourceCode r"><code class="sourceCode r"><span class="kw">library</span>(pander)
 <span class="kw">pandoc.table</span>(output, <span class="dt">emphasize.rows =</span> <span class="dv">1</span>, <span class="dt">emphasize.strong.cols =</span> <span class="dv">2</span>)</code></pre></div>
-<table style="width:58%;">
+<table style="width:62%;">
 <colgroup>
 <col width="19%"></col>
-<col width="18%"></col>
-<col width="20%"></col>
+<col width="19%"></col>
+<col width="23%"></col>
 </colgroup>
 <thead>
 <tr class="header">
@@ -10202,7 +10203,7 @@ Content C   | Content D
   (function () {
     var script = document.createElement("script");
     script.type = "text/javascript";
-    script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
+    script.src  = "https://mathjax.rstudio.com/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML";
     document.getElementsByTagName("head")[0].appendChild(script);
   })();
 </script>

--- a/tests/testthat/test-htmlTable.R
+++ b/tests/testthat/test-htmlTable.R
@@ -386,4 +386,30 @@ test_that("An empty dataframe returns an empty table with a warning", {
 test_that("HTML code is properly escaped", {
   expect_match(
     object = htmlTable(data.frame(a = "<3"), rnames = FALSE),
-    regexp = "&lt;3")})
+    regexp = "&lt;3")
+
+  df_test <- data.frame(a = c("<3", "<3"),
+                        b = c("&2", ">2"),
+                        stringsAsFactors = FALSE)
+  matrix_test <- as.matrix(df_test,
+                           ncol = 2)
+  tibble_test <- tibble::as.tibble(df_test)
+
+  expect_identical(htmlTable(df_test,
+                             rnames = FALSE),
+                   structure("<table class='gmisc_table' style='border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;' >\n<thead>\n<tr>\n<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; text-align: center;'>a</th>\n<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; text-align: center;'>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style='text-align: center;'>&lt;3</td>\n<td style='text-align: center;'>&amp;2</td>\n</tr>\n<tr>\n<td style='border-bottom: 2px solid grey; text-align: center;'>&lt;3</td>\n<td style='border-bottom: 2px solid grey; text-align: center;'>&gt;2</td>\n</tr>\n</tbody>\n</table>",
+                             class = c("htmlTable","character"),
+                             ... = list()))
+
+  expect_identical(htmlTable(matrix_test,
+                             rnames = FALSE),
+                   structure("<table class='gmisc_table' style='border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;' >\n<thead>\n<tr>\n<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; text-align: center;'>a</th>\n<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; text-align: center;'>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style='text-align: center;'>&lt;3</td>\n<td style='text-align: center;'>&amp;2</td>\n</tr>\n<tr>\n<td style='border-bottom: 2px solid grey; text-align: center;'>&lt;3</td>\n<td style='border-bottom: 2px solid grey; text-align: center;'>&gt;2</td>\n</tr>\n</tbody>\n</table>",
+                             class = c("htmlTable","character"),
+                             ... = list()))
+
+  expect_identical(htmlTable(tibble_test,
+                             rnames = FALSE),
+                   structure("<table class='gmisc_table' style='border-collapse: collapse; margin-top: 1em; margin-bottom: 1em;' >\n<thead>\n<tr>\n<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; text-align: center;'>a</th>\n<th style='border-bottom: 1px solid grey; border-top: 2px solid grey; text-align: center;'>b</th>\n</tr>\n</thead>\n<tbody>\n<tr>\n<td style='text-align: center;'>&lt;3</td>\n<td style='text-align: center;'>&amp;2</td>\n</tr>\n<tr>\n<td style='border-bottom: 2px solid grey; text-align: center;'>&lt;3</td>\n<td style='border-bottom: 2px solid grey; text-align: center;'>&gt;2</td>\n</tr>\n</tbody>\n</table>",
+                             class = c("htmlTable","character"),
+                             ... = list()))
+  })

--- a/vignettes/tables.Rmd
+++ b/vignettes/tables.Rmd
@@ -208,7 +208,7 @@ htmlTable(txtRound(mx, 1),
           cspan.rgroup = 1)
 ```
 
-If you want to further add to the visual hints you can use specific HTML-code and insert it into the cells. Here we will color the &Delta;<sub>std</sub> according to color.
+If you want to further add to the visual hints you can use specific HTML-code and insert it into the cells. Here we will color the &Delta;<sub>std</sub> according to color. By default htmlTable escapes HTML characters. If we want the HTML code to be interpreted correctly we need to make sure that this does not happen, by specifying `escape.html = FALSE`.
 
 ```{r}
 cols_2_clr <- grep("&Delta;<sub>std</sub>", colnames(mx))
@@ -249,7 +249,8 @@ htmlTable(out_mx,
           n.rgroup = rep(5, 3),
           tfoot = txtMergeLines("&Delta;<sub>int</sub> correspnds to the change since start",
                                 "&Delta;<sub>std</sub> corresponds to the change compared to national average"),
-          cspan.rgroup = 1)
+          cspan.rgroup = 1,
+          escape.html = FALSE)
 ```
 
 Although a graph most likely does the visualization task better, tables are good at conveying detailed information. It is in my mind without doubt easier in the latest version to find the pattern in the data.


### PR DESCRIPTION
Another try for issue #40. This should be more general: I've added tests for `matrix`, `data.frame` and `tibble`. I've also updated the vignette: it now shows how to _not_ escape html.