### PR TITLE
Add skips if packages are missing

### DIFF
--- a/tests/testthat/test-htmlTable_dates.R
+++ b/tests/testthat/test-htmlTable_dates.R
@@ -7,6 +7,8 @@ context('dates within htmlTable')
 
 # A simple example
 test_that("should be converted into strings (if fails check availability of chron package)", {
+  skip_if_not_installed("lubridate")
+  skip_if_not_installed("chron")
 
   # Below example is created using lemna's example:
   # library(lubridate)


### PR DESCRIPTION
Otherwise the test fails quite cryptically. The `require()` also fail silently so it's hard to tell why the test failed when I didn't have `chron` installed.